### PR TITLE
use json validation for report-to header

### DIFF
--- a/src/CSP_Manager/Settings.php
+++ b/src/CSP_Manager/Settings.php
@@ -574,6 +574,10 @@ class Settings {
      */
     public function pre_update_option(array $new_value): array {
         foreach ($new_value as $key => $value) {
+            if (strpos($key, 'header_reportto') !== false) {
+                $new_value[$key] = empty(trim($value)) || empty(json_decode($value)) ? '' : $value;
+                continue;
+            }
             // If this is the option for a directive value, sanitize it.
             if($key != 'mode' || !(strpos($key, 'enable_') === 0) || (array_key_exists($key, $this->directives) && !array_key_exists('type', $this->directives[$key]))) {
                 // Replace newlines with spaces


### PR DESCRIPTION
Allows saving JSON values for the [Report-To header](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/report-to).

Addresses https://github.com/16patsle/wordpress-csp-manager/issues/10