### PR TITLE
Fix: Prevent Over-Sanitization of header_reportto Field to Allow Valid JSON Payload

### DIFF
--- a/src/CSP_Manager/Settings.php
+++ b/src/CSP_Manager/Settings.php
@@ -574,6 +574,12 @@ class Settings {
      */
     public function pre_update_option(array $new_value): array {
         foreach ($new_value as $key => $value) {
+
+			// Do not sanitize header_* fields (e.g. header_reportto) to preserve JSON.
+			if (strpos((string) $key, 'header_') === 0) {
+            	continue;
+			}
+			
             // If this is the option for a directive value, sanitize it.
             if($key != 'mode' || !(strpos($key, 'enable_') === 0) || (array_key_exists($key, $this->directives) && !array_key_exists('type', $this->directives[$key]))) {
                 // Replace newlines with spaces


### PR DESCRIPTION
This fix addresses a bug where the pre_update_option() sanitization logic in Settings::pre_update_option() was incorrectly applied to the header_reportto field. This logic, designed for sanitizing Content Security Policy (CSP) directive values, was stripping commas (,) from the JSON payload intended for the Report-To header, making the header invalid and preventing the Reporting API from functioning.

Details
The plugin emits a Report-To header using the value from the header_reportto field in Settings.php:

```
PHP

if (isset($option['header_reportto']) && !empty($option['header_reportto'])) {
    header(sprintf('Report-To: %s', $option['header_reportto']));
}
```
The required value for this field is a valid JSON object, for example:

```
JSON

{"group":"csp-learn","max_age":10886400,"endpoints":[{"url":"https://example.com/wp-json/wsr/v1/csp/report-to"}]}
```
However, the existing sanitization regex: $regex = '/[^\x21-\x2B\x2D-\x3A\x3C-\x7E\x09\x20]/u';


...incorrectly treats the header_reportto field as a standard CSP directive value, removing characters essential for JSON syntax, such as the comma.

This PR modifies Settings::pre_update_option() to skip sanitization for all fields starting with header_ (e.g., header_reportto). This ensures that valid JSON can be stored and correctly emitted as the Report-To header.

Changes
In Settings::pre_update_option():

```
PHP

// Do not sanitize header_* fields (e.g. header_reportto) to preserve JSON.
if (strpos((string) $key, 'header_') === 0) {
    continue;
}
```
This change preserves the JSON integrity for the Report-To header, allowing browsers to correctly process the header and send reports to the specified Reporting API endpoint.